### PR TITLE
IOS-13938: Fix build errors on Xcode 27 (beta)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
                 .unsafeFlags(["-fno-objc-arc"])
             ],
             linkerSettings: [
-                .unsafeFlags(["-ObjC"])
+                .unsafeFlags(["-Xlinker", "-ObjC"])
             ]
         ),
     ]


### PR DESCRIPTION
The Swift 6.2 linker (Xcode 27) rejects a bare -ObjC linker flag with 'unknown argument: -ObjC' when it is used as the linker for dependent Swift dynamic products. Forwarding it with -Xlinker keeps the flag reaching ld while remaining accepted by swiftc.

Once this PR is merge, we need to go back to https://github.com/quizlet/quizlet-ios/pull/24409, change the branch back to `latests-bits`, resolve the new changes and push Package.swift and Package.resolved and push it again. 

Another side question could be why we are using branch and not main, or make releases and then use versions on quizlet ...